### PR TITLE
add <<< for backward composition in Haskell

### DIFF
--- a/concepts.json
+++ b/concepts.json
@@ -244,7 +244,7 @@
 				},
 				{
 					"name": "Haskell",
-					"code": ".",
+					"code": "<<<, .",
 					"example": ["employeeBossStreet = (street <<< address <<< boss) employee"
 										]
 				},


### PR DESCRIPTION
The `Control.Arrow` module in Haskell base has [`(<<<)`](https://www.stackage.org/haddock/lts-8.19/base-4.9.1.0/Control-Arrow.html#v:-60--60--60-) in addition to `(>>>)`. For function arrows, `(<<<)` specializes to `(.)`.